### PR TITLE
Move "@babel/runtime" to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,14 @@
   },
   "author": "",
   "license": "MIT",
+  "dependencies": {
+    "@babel/runtime": "^7.0.0",
+  },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.1",
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    "@babel/runtime": "^7.0.0",
     "eslint": "^5.5.0",
     "eslint-config-antife": "^1.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.0.0",
+    "@babel/runtime": "^7.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
`@babel/runtime` should be in the `dependencies`, otherwise there may be have problem like this

![image](https://user-images.githubusercontent.com/13585043/47101046-95b80980-d26b-11e8-8cd2-961abcb0df37.png)
